### PR TITLE
fix: improve Grafana 9 compatibility and prepare v2.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v2.1.1](https://github.com/leoswing/comparequeries-datasource-rc/tree/v2.1.1) (2026-05-25)
+
+[Full Changelog](https://github.com/leoswing/comparequeries-datasource-rc/compare/v2.1.0...v2.1.1)
+
+- fix: improve Grafana 9 compatibility for UI theme tokens with safe fallback handling.
+- fix: improve SQL/MySQL expression compatibility guidance for wide-series inputs.
+- chore: update compatibility wording and release metadata for submission.
+
 ## [v2.1.0](https://github.com/leoswing/comparequeries-datasource-rc/tree/v2.1.0) (2026-05-13)
 
 [Full Changelog](https://github.com/leoswing/comparequeries-datasource-rc/compare/2.0.3...v2.1.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leoswing-comparequeries-datasource",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leoswing-comparequeries-datasource",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leoswing-comparequeries-datasource",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Grafana plugin for compare queries",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
fix: improve Grafana 9 compatibility and prepare v2.1.1 release

- bump version to 2.1.1
- upgrade changelog
