### PR TITLE
feature: Add Ad-Hoc filter and expression variable replacement support with wraming up

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,29 @@ Use CompareQueries with Grafana [Math expressions](https://grafana.com/docs/graf
 
 Step-by-step setup, SQL/MySQL wide-series notes, and troubleshooting: **[Wiki — Mathematical Expressions](https://github.com/leoswing/comparequeries-datasource-rc/wiki/Mathematical-Expressions)**.
 
+## Dashboard Variables & Ad Hoc Filters
+
+Dashboard variables work in target queries and Math expressions. Multi-value selections are formatted for supported target datasources, including Elasticsearch, OpenSearch, Prometheus, Loki, InfluxQL, OpenTSDB, and SQL datasources.
+
+Explicit [Grafana variable formats](https://grafana.com/docs/grafana/latest/dashboards/variables/variable-syntax/) such as `${moduleName:raw}` remain authoritative.
+
+**Ad Hoc filters (Filter and Group by)**
+
+1. Create an **Ad hoc filters** variable and select **CompareQueries** as its datasource.
+2. Enable **Use static key dimensions**, then enter the fields users can filter by. Use one field per line in `Display label,fieldName` format:
+
+   ```text
+   moduleName,moduleName
+   type,type
+   plugin,plugin
+   ```
+
+   The first column is the label shown in Grafana; the second is the actual field name.
+3. To type filter values in the Grafana UI, enable **Allow custom values**.
+4. To set filters from a dashboard URL, add one `var-filter` parameter per filter. Example: `var-filter=moduleName%7C%3D%7Caction` represents `moduleName = action`. URL filters do not require **Allow custom values**.
+
+CompareQueries does not provide automatic field or value suggestions, so configure static fields and enter values manually. To confirm a filter is active, open **Query inspector** and check that the final target query includes the selected condition.
+
 ## Datasource Settings
 
 Configure the CompareQueries datasource in **Connections -> Data sources**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leoswing-comparequeries-datasource",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leoswing-comparequeries-datasource",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leoswing-comparequeries-datasource",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Grafana plugin for compare queries",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -103,6 +103,9 @@ func (d *Datasource) handleQuery(ctx context.Context, client *GrafanaClient, q b
 		return backend.ErrDataResponse(backend.StatusBadRequest, "at least one time shift is required")
 	}
 
+	// Treat targetQueryJSON as an opaque target-datasource payload. CompareQueries cannot
+	// distinguish unresolved dashboard variables from datasource-specific macros, so the
+	// target datasource remains responsible for interpolation and validation.
 	var allFrames data.Frames
 
 	for _, ts := range qm.TimeShifts {
@@ -257,9 +260,12 @@ func (d *Datasource) filterFrameByRange(frame *data.Frame, from, to time.Time) {
 	}
 }
 
-// applyAlias renames numeric field names/display names to include the time shift alias,
-// and injects a "timeshift" label so Grafana Alerting can distinguish series during union.
+// applyAlias aliases field-level names while keeping frame.Name unchanged.
+// DisplayNameFromDS prevents Grafana from appending frame and timeshift labels again.
+// The "timeshift" label lets Grafana Alerting distinguish series during union.
 func (d *Datasource) applyAlias(frame *data.Frame, alias, aliasType, delimiter string) {
+	singleField := singleSeriesField(frame)
+
 	for _, field := range frame.Fields {
 		if field.Type() == data.FieldTypeTime || field.Type() == data.FieldTypeNullableTime {
 			continue
@@ -267,13 +273,18 @@ func (d *Datasource) applyAlias(frame *data.Frame, alias, aliasType, delimiter s
 
 		field.Name = generalAlias(field.Name, alias, aliasType, delimiter)
 
-		if field.Config != nil {
-			if field.Config.DisplayName != "" {
-				field.Config.DisplayName = generalAlias(field.Config.DisplayName, alias, aliasType, delimiter)
-			}
-			if field.Config.DisplayNameFromDS != "" {
-				field.Config.DisplayNameFromDS = generalAlias(field.Config.DisplayNameFromDS, alias, aliasType, delimiter)
-			}
+		if field.Config == nil {
+			field.Config = &data.FieldConfig{}
+		}
+		if field.Config.DisplayName != "" {
+			field.Config.DisplayName = generalAlias(field.Config.DisplayName, alias, aliasType, delimiter)
+		}
+		if field.Config.DisplayNameFromDS != "" {
+			field.Config.DisplayNameFromDS = generalAlias(field.Config.DisplayNameFromDS, alias, aliasType, delimiter)
+		} else if field == singleField && frame.Name != "" {
+			field.Config.DisplayNameFromDS = generalAlias(frame.Name, alias, aliasType, delimiter)
+		} else {
+			field.Config.DisplayNameFromDS = field.Name
 		}
 
 		// Inject timeshift label so Grafana Alerting union can distinguish series from
@@ -283,6 +294,20 @@ func (d *Datasource) applyAlias(frame *data.Frame, alias, aliasType, delimiter s
 		}
 		field.Labels["timeshift"] = alias
 	}
+}
+
+func singleSeriesField(frame *data.Frame) *data.Field {
+	var result *data.Field
+	for _, field := range frame.Fields {
+		if field.Type() == data.FieldTypeTime || field.Type() == data.FieldTypeNullableTime {
+			continue
+		}
+		if result != nil {
+			return nil
+		}
+		result = field
+	}
+	return result
 }
 
 func generalAlias(original, alias, aliasType, delimiter string) string {

--- a/pkg/plugin/timeshift_test.go
+++ b/pkg/plugin/timeshift_test.go
@@ -3,6 +3,8 @@ package plugin
 import (
 	"testing"
 	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
 func TestParseTimeShift(t *testing.T) {
@@ -119,5 +121,72 @@ func TestGeneralAlias(t *testing.T) {
 			t.Errorf("generalAlias(%q, %q, %q, %q) = %q, want %q",
 				tt.original, tt.alias, tt.aliasType, tt.delimiter, result, tt.expected)
 		}
+	}
+}
+
+func TestApplyAliasKeepsFrameNameSeparateFromFieldName(t *testing.T) {
+	frame := data.NewFrame(
+		"test",
+		data.NewField("Time", nil, []time.Time{time.Now()}),
+		data.NewField("Value", nil, []float64{1}),
+	)
+
+	(&Datasource{}).applyAlias(frame, "3d", "suffix", "test_de")
+
+	if frame.Name != "test" {
+		t.Errorf("frame name = %q, want %q", frame.Name, "test")
+	}
+	if frame.Fields[0].Name != "Time" {
+		t.Errorf("time field name = %q, want %q", frame.Fields[0].Name, "Time")
+	}
+	if frame.Fields[1].Name != "Valuetest_de3d" {
+		t.Errorf("value field name = %q, want %q", frame.Fields[1].Name, "Valuetest_de3d")
+	}
+	if got := frame.Fields[1].Config.DisplayNameFromDS; got != "testtest_de3d" {
+		t.Errorf("display name from datasource = %q, want %q", got, "testtest_de3d")
+	}
+	if got := frame.Fields[1].Labels["timeshift"]; got != "3d" {
+		t.Errorf("timeshift label = %q, want %q", got, "3d")
+	}
+}
+
+func TestApplyAliasKeepsWideFrameDisplayNamesDistinct(t *testing.T) {
+	frame := data.NewFrame(
+		"orders",
+		data.NewField("Time", nil, []time.Time{time.Now()}),
+		data.NewField("success", nil, []float64{1}),
+		data.NewField("failure", nil, []float64{2}),
+	)
+	(&Datasource{}).applyAlias(frame, "1d", "suffix", "_")
+
+	if got := frame.Fields[1].Name; got != "success_1d" {
+		t.Errorf("success field name = %q, want %q", got, "success_1d")
+	}
+	if got := frame.Fields[2].Name; got != "failure_1d" {
+		t.Errorf("failure field name = %q, want %q", got, "failure_1d")
+	}
+	if got := frame.Fields[1].Config.DisplayNameFromDS; got != "success_1d" {
+		t.Errorf("success display name from datasource = %q, want %q", got, "success_1d")
+	}
+	if got := frame.Fields[2].Config.DisplayNameFromDS; got != "failure_1d" {
+		t.Errorf("failure display name from datasource = %q, want %q", got, "failure_1d")
+	}
+}
+
+func TestApplyAliasKeepsMixedFrameDisplayNamesDistinct(t *testing.T) {
+	frame := data.NewFrame(
+		"orders",
+		data.NewField("Time", nil, []time.Time{time.Now()}),
+		data.NewField("status", nil, []string{"success"}),
+		data.NewField("count", nil, []float64{1}),
+	)
+
+	(&Datasource{}).applyAlias(frame, "1d", "suffix", "_")
+
+	if got := frame.Fields[1].Config.DisplayNameFromDS; got != "status_1d" {
+		t.Errorf("dimension display name from datasource = %q, want %q", got, "status_1d")
+	}
+	if got := frame.Fields[2].Config.DisplayNameFromDS; got != "count_1d" {
+		t.Errorf("value display name from datasource = %q, want %q", got, "count_1d")
 	}
 }

--- a/provisioning/dashboards/dashboards.yml
+++ b/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'CompareQueries E2E'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/provisioning/dashboards/variable-expression.json
+++ b/provisioning/dashboards/variable-expression.json
@@ -1,0 +1,180 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "1m"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "elasticsearch-e2e"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "type:log AND moduleName: $moduleName",
+          "refId": "A",
+          "timeField": "@timestamp"
+        },
+        {
+          "aliasTypes": [
+            "suffix",
+            "prefix",
+            "absolute"
+          ],
+          "datasource": {
+            "type": "leoswing-comparequeries-datasource",
+            "uid": "comparequeries-e2e"
+          },
+          "datasourceUid": "elasticsearch-e2e",
+          "process": true,
+          "refId": "B",
+          "targetQueryJSON": {
+            "bucketAggs": [
+              {
+                "field": "@timestamp",
+                "id": "2",
+                "settings": {
+                  "interval": "1m"
+                },
+                "type": "date_histogram"
+              }
+            ],
+            "metrics": [
+              {
+                "id": "1",
+                "type": "count"
+              }
+            ],
+            "query": "type:log AND moduleName: $moduleName",
+            "timeField": "@timestamp"
+          },
+          "timeShifts": [
+            {
+              "id": 0,
+              "value": "1d"
+            }
+          ],
+          "units": [
+            "y",
+            "M",
+            "w",
+            "d",
+            "h",
+            "m",
+            "s"
+          ]
+        },
+        {
+          "datasource": {
+            "name": "Expression",
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$B",
+          "refId": "C",
+          "type": "math"
+        }
+      ],
+      "title": "Variable Expression",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 40,
+  "tags": [
+    "comparequeries-e2e"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": [
+            "action",
+            "default",
+            "charge"
+          ],
+          "value": [
+            "action",
+            "default",
+            "charge"
+          ]
+        },
+        "includeAll": false,
+        "label": "Module",
+        "multi": true,
+        "name": "moduleName",
+        "options": [
+          {
+            "selected": true,
+            "text": "action",
+            "value": "action"
+          },
+          {
+            "selected": true,
+            "text": "default",
+            "value": "default"
+          },
+          {
+            "selected": true,
+            "text": "charge",
+            "value": "charge"
+          }
+        ],
+        "query": "action,default,charge",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "CompareQueries Variable Expression E2E",
+  "uid": "comparequeries-vars-e2e",
+  "version": 1
+}

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -9,3 +9,27 @@ datasources:
     version: 1
     editable: true
     jsonData: {}
+
+  - name: 'CompareQueries E2E'
+    uid: 'comparequeries-e2e'
+    type: 'leoswing-comparequeries-datasource'
+    access: proxy
+    isDefault: false
+    orgId: 1
+    version: 1
+    editable: true
+    jsonData:
+      authMode: 'none'
+
+  - name: 'Elasticsearch E2E'
+    uid: 'elasticsearch-e2e'
+    type: 'elasticsearch'
+    access: proxy
+    url: 'http://127.0.0.1:1'
+    isDefault: false
+    orgId: 1
+    version: 1
+    editable: true
+    jsonData:
+      index: 'comparequeries-e2e'
+      timeField: '@timestamp'

--- a/src/README.md
+++ b/src/README.md
@@ -11,6 +11,8 @@ Key features:
 - Resolves issues with undefined data points
 - Introduces support for timeShift aliases
 - Supports Grafana Alerting through backend execution
+- Delegates dashboard variables and Ad Hoc filters to target datasources
+- Supports Math expressions with multi-value variables (v2.1.0+)
 
 ![Plugin-snapshot](https://raw.githubusercontent.com/leoswing/comparequeries-datasource-rc/main/src/img/compare-func.png)
 
@@ -42,6 +44,25 @@ Step 6. Pick `Target Datasource` inside CompareQueries, build target query inlin
 
 ![Screenshot-plugin-usage-mixed](https://raw.githubusercontent.com/leoswing/comparequeries-datasource-rc/main/img/plugin-usage-mixed.png)
 
+# Dashboard variables & Ad Hoc filters
+
+CompareQueries delegates variable and Ad Hoc filter formatting to the **target datasource** (Elasticsearch, Prometheus, SQL, etc.). It does not maintain per-datasource multi-value syntax rules.
+
+- **Panel / Math expression / Alerting**: `targetQueryJSON` is interpolated via the target plugin's `applyTemplateVariables` when available.
+- **Multi-value variables**: formatted by the target (e.g. Elasticsearch → `("a" OR "b" OR "c")`), not CompareQueries' glob fallback `{a,b,c}`.
+- **Ad Hoc filters**: select **CompareQueries** as the variable datasource, enable **Use static key dimensions**, and enter fields as `label,fieldName` (for example, `moduleName,moduleName`). Enable **Allow custom values** only when users need to type values in the Grafana UI.
+- **URL filters**: pass one `var-filter` parameter per filter, for example `var-filter=moduleName%7C%3D%7Caction`. URL filters do not require **Allow custom values**.
+- **Verify**: open Query inspector and check that the final target query includes the selected filters.
+
+# Mathematical expressions (2.1.0+)
+
+Use with Grafana [Math expressions](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/expression-queries/) in a `-- Mixed --` panel: base query + CompareQueries shifted query + Expression row.
+
+- Enable **Basic authentication** + **Service Account token** on the CompareQueries datasource when backend expression execution requires auth.
+- Enable **Process TimeShift** when the expression must align shifted series on the same time axis.
+
+Details: [Wiki — Mathematical Expressions](https://github.com/leoswing/comparequeries-datasource-rc/wiki/Mathematical-Expressions).
+
 # Legacy RefId usage (Grafana < 13 existing dashboards only)
 
 Use this only if you are on Grafana versions below 13 and already have dashboards using the old CompareQueries RefId workflow.
@@ -57,6 +78,7 @@ For Grafana 13+, use Step 4 recommended flow instead: select `Target Datasource`
 Alerting uses backend execution. Alert rules do not use the panel `-- Mixed --` datasource flow.
 Configure CompareQueries directly with `Target Datasource`, `Time shift`, and query inline.
 
+- The backend treats `targetQueryJSON` as an opaque target-datasource payload. Any remaining variables or datasource-specific macros are forwarded for the target datasource to validate.
 - Default datasource auth mode is `No Authentication`.
 - If backend or alerting requests fail authentication, switch to `Basic authentication`.
 - In `Basic authentication`, configure `Service Account` token and (optionally) `Grafana URL`.

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -71,7 +71,7 @@ function stripReservedFields(payload: Record<string, any>): Record<string, any> 
   return out;
 }
 
-export function QueryEditor({ query, onChange, onRunQuery, data }: Props) {
+export function QueryEditor({ query, onChange, onRunQuery, data, datasource }: Props) {
   const lastRunValueRef = useRef<Record<string, any> | null>(null);
 
   const aliasTypes = ['suffix', 'prefix', 'absolute'];
@@ -265,7 +265,8 @@ export function QueryEditor({ query, onChange, onRunQuery, data }: Props) {
   const [targetDsError, setTargetDsError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!target.datasourceUid) {
+    const datasourceUid = target.datasourceUid;
+    if (!datasourceUid) {
       setTargetDs(null);
       setTargetDsError(null);
       setTargetDsLoading(false);
@@ -277,28 +278,30 @@ export function QueryEditor({ query, onChange, onRunQuery, data }: Props) {
     setTargetDsError(null);
 
     getDataSourceSrv()
-      .get({ uid: target.datasourceUid })
+      .get({ uid: datasourceUid })
       .then((ds) => {
         if (cancelled) {
           return;
         }
-        setTargetDs(ds as unknown as DataSourceApi);
+        datasource.registerTargetDatasource(datasourceUid, ds);
+        setTargetDs(ds);
         setTargetDsLoading(false);
       })
-      .catch((err: any) => {
+      .catch((err: unknown) => {
         if (cancelled) {
           return;
         }
         console.warn('CompareQueries: failed to load target datasource', err);
         setTargetDs(null);
-        setTargetDsError(err?.message ?? String(err));
+        const message = err instanceof Error && err.message ? err.message : String(err);
+        setTargetDsError(message);
         setTargetDsLoading(false);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [target.datasourceUid]);
+  }, [target.datasourceUid, datasource]);
 
   // Resolve the embedded editor component contributed by the target datasource plugin.
   // Every standard Grafana datasource plugin exposes this (Prometheus, Elasticsearch, Loki, SQL,

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,7 +1,46 @@
+import type { AdHocVariableFilter } from '@grafana/data';
+
 import { DataSource } from './datasource';
 
 const mockGetDataSourceSrv = jest.fn();
 const mockGetTemplateSrv = jest.fn();
+
+function createTemplateReplace(moduleValue: string | string[] = ['action', 'default', 'charge']) {
+  return (
+    input: string,
+    _scopedVars?: unknown,
+    formatter?: (
+      value: unknown,
+      variable: unknown,
+      formatVariableValue: (value: unknown, format?: string) => string
+    ) => string
+  ): string => {
+    const formatVariableValue = (value: unknown, format?: string): string => {
+      const values = Array.isArray(value) ? value.map(String) : [String(value)];
+      switch (format) {
+        case 'csv':
+          return values.join(',');
+        case 'lucene':
+          return values.length > 1 ? `(${values.map((item) => `"${item}"`).join(' OR ')})` : values[0];
+        case 'regex':
+          return values.length > 1 ? `(${values.join('|')})` : values[0];
+        case 'pipe':
+          return values.join('|');
+        case 'sqlstring':
+          return values.map((item) => `'${item}'`).join(',');
+        default:
+          return values.length > 1 ? `{${values.join(',')}}` : values[0];
+      }
+    };
+    const replacement = typeof formatter === 'function'
+      ? formatter(moduleValue, { name: 'moduleName', multi: Array.isArray(moduleValue) }, formatVariableValue)
+      : formatVariableValue(moduleValue);
+
+    return input
+      .replace(/\$\{moduleName:glob\}/g, formatVariableValue(moduleValue))
+      .replace(/\$moduleName/g, replacement);
+  };
+}
 
 jest.mock('@grafana/runtime', () => ({
   getDataSourceSrv: () => mockGetDataSourceSrv(),
@@ -140,6 +179,869 @@ describe('DataSource', () => {
       expect(result.data[0].target).toBe('error_1d');
     });
 
+    it('delegates variable interpolation on the first frontend query', async () => {
+      const queryMock = jest.fn().mockResolvedValue({
+        data: [{ target: 'metric' }],
+      });
+      const applyTemplateVariables = jest.fn((query: Record<string, unknown>) => ({
+        ...query,
+        expr: 'up{job=~"(api|worker)"}',
+      }));
+      mockGetDataSourceSrv.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          meta: { id: 'prometheus' },
+          query: queryMock,
+          applyTemplateVariables,
+        }),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      await (ds as any)._runSelfContained(
+        {
+          requestId: 'req-first-run',
+          range: {
+            from: new Date(0),
+            to: new Date(1),
+            raw: {},
+          },
+          scopedVars: {
+            job: { value: ['api', 'worker'], text: 'api + worker' },
+          },
+        },
+        {
+          refId: 'A',
+          datasourceUid: 'prom-uid',
+          targetQueryJSON: { expr: 'up{job=~"$job"}' },
+          timeShifts: [{ id: 0, value: '' }],
+        }
+      );
+
+      expect(applyTemplateVariables).toHaveBeenCalledTimes(1);
+      expect(queryMock.mock.calls[0][0].targets[0].expr).toBe('up{job=~"(api|worker)"}');
+    });
+
+    it('does not delegate twice after expression preparation', async () => {
+      const queryMock = jest.fn().mockResolvedValue({
+        data: [{ target: 'metric' }],
+      });
+      const applyTemplateVariables = jest.fn((query: Record<string, unknown>) => ({
+        ...query,
+        expr: 'up{job=~"(api|worker)"}',
+      }));
+      const targetDs = {
+        meta: { id: 'prometheus' },
+        query: queryMock,
+        applyTemplateVariables,
+      };
+      mockGetDataSourceSrv.mockReturnValue({
+        get: jest.fn().mockResolvedValue(targetDs),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+      ds.registerTargetDatasource('prom-uid', targetDs);
+
+      const filters = [{ key: 'cluster', operator: '=', value: 'prod' }];
+      const [prepared] = ds.interpolateVariablesInQueries(
+        [{
+          refId: 'A',
+          query: '',
+          timeShifts: [{ id: 0, value: '' }],
+          aliasTypes: [],
+          units: [],
+          process: true,
+          datasourceUid: 'prom-uid',
+          targetQueryJSON: { expr: 'up{job=~"$job"}' },
+        }],
+        { job: { value: ['api', 'worker'], text: 'api + worker' } },
+        filters
+      );
+
+      await (ds as any)._runSelfContained(
+        {
+          requestId: 'req-prepared',
+          range: {
+            from: new Date(0),
+            to: new Date(1),
+            raw: {},
+          },
+          scopedVars: {
+            job: { value: ['api', 'worker'], text: 'api + worker' },
+          },
+          filters,
+        },
+        prepared
+      );
+
+      expect(applyTemplateVariables).toHaveBeenCalledTimes(1);
+      expect(queryMock.mock.calls[0][0].targets[0].expr).toBe('up{job=~"(api|worker)"}');
+    });
+
+    it('applyTemplateVariables expands nested targetQueryJSON for backend queries', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: (value: string) =>
+          value.replace(/\$moduleName/g, 'basic-product').replace(/\$environment/g, 'production'),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const query = {
+        refId: 'B',
+        query: '',
+        timeShifts: [{ id: 0, value: '1d' }],
+        aliasTypes: [],
+        units: [],
+        process: true,
+        targetQueryJSON: {
+          query: 'type:log AND moduleName: $moduleName',
+          nested: {
+            environment: '$environment',
+            values: ['$moduleName', 1, true],
+          },
+        },
+      };
+      const scopedVars = {
+        moduleName: { value: 'basic-product', text: 'basic-product' },
+        environment: { value: 'production', text: 'production' },
+      };
+      const result = ds.applyTemplateVariables(query, scopedVars);
+
+      expect(result.targetQueryJSON).toEqual({
+        query: 'type:log AND moduleName: basic-product',
+        nested: {
+          environment: 'production',
+          values: ['basic-product', 1, true],
+        },
+      });
+      expect(query.targetQueryJSON).toEqual({
+        query: 'type:log AND moduleName: $moduleName',
+        nested: {
+          environment: '$environment',
+          values: ['$moduleName', 1, true],
+        },
+      });
+    });
+
+    it('bridges legacy Ad Hoc filters without mutating the target datasource', () => {
+      const legacyFilters = [{ key: 'moduleName', operator: '=', value: 'basic-product' }];
+      const getAdhocFilters = jest.fn().mockReturnValue(legacyFilters);
+      mockGetTemplateSrv.mockReturnValue({
+        replace: (value: string) => value,
+        getAdhocFilters,
+      });
+      const targetGetAdhocFilters = jest.fn().mockReturnValue([]);
+      const targetTemplateSrv = {
+        getAdhocFilters: targetGetAdhocFilters,
+      };
+      const legacyTargetDs = {
+        name: 'Elasticsearch',
+        templateSrv: targetTemplateSrv,
+        applyTemplateVariables(query: Record<string, unknown>, _scopedVars: unknown) {
+          const filters = this.templateSrv.getAdhocFilters(this.name);
+          const filterQuery = filters.map((filter: AdHocVariableFilter) => `${filter.key}:\"${filter.value}\"`).join(' AND ');
+          return {
+            ...query,
+            query: [query.query, filterQuery].filter(Boolean).join(' AND '),
+          };
+        },
+      };
+      const ds = new DataSource({
+        id: 1,
+        uid: 'comparequeries-uid',
+        name: 'CompareQueries',
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+      ds.registerTargetDatasource('es-uid', legacyTargetDs);
+
+      const result = ds.applyTemplateVariables(
+        {
+          refId: 'B',
+          datasourceUid: 'es-uid',
+          targetQueryJSON: { query: 'type: log' },
+        } as any,
+        {}
+      );
+
+      expect(result.targetQueryJSON).toEqual({
+        query: 'type: log AND moduleName:"basic-product"',
+      });
+      expect(getAdhocFilters).toHaveBeenCalledWith('CompareQueries');
+      expect(targetGetAdhocFilters).not.toHaveBeenCalled();
+      expect(legacyTargetDs.templateSrv).toBe(targetTemplateSrv);
+    });
+
+    it('keeps an explicitly empty modern filter list authoritative', () => {
+      const getAdhocFilters = jest.fn().mockReturnValue([
+        { key: 'moduleName', operator: '=', value: 'stale-value' },
+      ]);
+      mockGetTemplateSrv.mockReturnValue({
+        replace: (value: string) => value,
+        getAdhocFilters,
+      });
+      const applyTemplateVariables = jest.fn(
+        (query: Record<string, unknown>, _scopedVars?: unknown, _filters?: unknown) => query
+      );
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+      ds.registerTargetDatasource('es-uid', { applyTemplateVariables });
+
+      ds.applyTemplateVariables(
+        {
+          refId: 'B',
+          datasourceUid: 'es-uid',
+          targetQueryJSON: { query: 'type: log' },
+        } as any,
+        {},
+        []
+      );
+
+      expect(getAdhocFilters).not.toHaveBeenCalled();
+      expect(applyTemplateVariables.mock.calls[0][2]).toEqual([]);
+    });
+
+    it('delegates interpolation to target datasource when cached', () => {
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      // Simulate a cached target datasource that formats lucene-style
+      const applyTemplateVariables = jest.fn(
+        (query: Record<string, unknown>, _scopedVars?: unknown, _filters?: unknown) => ({
+          ...query,
+          query: 'moduleName: ("action" OR "default" OR "charge")',
+        })
+      );
+      const fakeTargetDs = {
+        applyTemplateVariables,
+      };
+      ds.registerTargetDatasource('es-uid', fakeTargetDs);
+      const filters = [{ key: 'environment', operator: '=', value: 'production' }];
+
+      const result = ds._interpolateTargetQueryJSON(
+        '{"query":"moduleName: $moduleName"}',
+        { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } },
+        { datasourceUid: 'es-uid', refId: 'B', filters }
+      );
+
+      expect(result).toEqual({
+        query: 'moduleName: ("action" OR "default" OR "charge")',
+      });
+      expect(applyTemplateVariables.mock.calls[0][2]).toBe(filters);
+    });
+
+    it('delegates interpolation to a datasource already loaded by Grafana on cold start', () => {
+      const applyTemplateVariables = jest.fn((query: Record<string, unknown>) => ({
+        ...query,
+        query: 'type:log AND moduleName: ("action" OR "default" OR "charge")',
+      }));
+      mockGetDataSourceSrv.mockReturnValue({
+        get: jest.fn(),
+        datasources: {
+          'es-uid': {
+            applyTemplateVariables,
+          },
+        },
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+      const result = ds._interpolateTargetQueryJSON(
+        '{"query":"type:log AND moduleName: $moduleName"}',
+        { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } },
+        { datasourceUid: 'es-uid', refId: 'B' }
+      );
+
+      expect(result).toEqual({
+        query: 'type:log AND moduleName: ("action" OR "default" OR "charge")',
+      });
+      expect(applyTemplateVariables).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses Grafana default formatting when target datasource is unavailable', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: (value: string, _scopedVars?: unknown, format?: string) =>
+          value.replace(/\$moduleName/g, format === undefined ? '{action,default,charge}' : 'unexpected'),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const result = ds._interpolateTargetQueryJSON(
+        '{"query":"type:log AND moduleName: $moduleName"}',
+        { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } },
+        { datasourceUid: 'unknown-uid', refId: 'B' }
+      );
+
+      expect(result).toEqual({
+        query: 'type:log AND moduleName: {action,default,charge}',
+      });
+    });
+
+    it('formats fallback glob groups as lucene for elasticsearch targets', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: createTemplateReplace(),
+      });
+      mockGetDataSourceSrv.mockReturnValue({
+        get: jest.fn(),
+        getInstanceSettings: jest.fn((uid: string) =>
+          uid === 'es-uid' ? { type: 'elasticsearch' } : undefined
+        ),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const [result] = ds.interpolateVariablesInQueries(
+        [{
+          refId: 'A',
+          query: '',
+          timeShifts: [],
+          aliasTypes: [],
+          units: [],
+          process: true,
+          datasourceUid: 'es-uid',
+          targetQueryJSON: { query: 'moduleName: $moduleName' },
+        }],
+        { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } }
+      );
+
+      expect(result.targetQueryJSON).toEqual({ query: 'moduleName: ("action" OR "default" OR "charge")' });
+    });
+
+    it('recovers original scoped arrays when Grafana pre-joins formatter values', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: (
+          input: string,
+          _scopedVars?: unknown,
+          formatter?: (value: unknown, variable: unknown) => string
+        ) => input.replace(
+          /\$moduleName/g,
+          formatter?.('action,default,charge', { name: 'moduleName', type: 'scopedvar' }) ?? ''
+        ),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const [result] = ds.interpolateVariablesInQueries(
+        [{
+          refId: 'A',
+          query: '',
+          timeShifts: [],
+          aliasTypes: [],
+          units: [],
+          process: true,
+          datasourceType: 'elasticsearch',
+          targetQueryJSON: { query: 'moduleName: $moduleName' },
+        }],
+        { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } }
+      );
+
+      expect(result.targetQueryJSON).toEqual({ query: 'moduleName: ("action" OR "default" OR "charge")' });
+    });
+
+    it('uses dashboard variable state when expression scopedVars omit the multi-value variable', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: (
+          input: string,
+          _scopedVars?: unknown,
+          formatter?: (value: unknown, variable: unknown) => string
+        ) => input.replace(
+          /\$moduleName/g,
+          formatter?.(['action', 'default', 'charge'], { name: 'moduleName', multi: true }) ?? ''
+        ),
+      });
+      mockGetDataSourceSrv.mockReturnValue({
+        get: jest.fn(),
+        getInstanceSettings: jest.fn((uid: string) =>
+          uid === 'es-uid' ? { type: 'elasticsearch' } : undefined
+        ),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const [result] = ds.interpolateVariablesInQueries(
+        [{
+          refId: 'A',
+          query: '',
+          timeShifts: [],
+          aliasTypes: [],
+          units: [],
+          process: true,
+          datasourceUid: 'es-uid',
+          targetQueryJSON: { query: 'moduleName: $moduleName' },
+        }],
+        { __interval: { value: '30s', text: '30s' } }
+      );
+
+      expect(result.targetQueryJSON).toEqual({ query: 'moduleName: ("action" OR "default" OR "charge")' });
+    });
+
+    it('formats fallback glob groups as lucene for opensearch targets', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: createTemplateReplace(),
+      });
+      mockGetDataSourceSrv.mockReturnValue({
+        get: jest.fn(),
+        getInstanceSettings: jest.fn((uid: string) =>
+          uid === 'os-uid' ? { type: 'grafana-opensearch-datasource' } : undefined
+        ),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const [result] = ds.interpolateVariablesInQueries(
+        [{
+          refId: 'A',
+          query: '',
+          timeShifts: [],
+          aliasTypes: [],
+          units: [],
+          process: true,
+          datasourceUid: 'os-uid',
+          targetQueryJSON: { query: 'moduleName: $moduleName' },
+        }],
+        { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } }
+      );
+
+      expect(result.targetQueryJSON).toEqual({ query: 'moduleName: ("action" OR "default" OR "charge")' });
+    });
+
+    it('uses default fallback when expressions prepare queries without a delegate', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: (value: string) => value.replace(/\$moduleName/g, '{action,default,charge}'),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const [result] = ds.interpolateVariablesInQueries(
+        [{
+          refId: 'B',
+          query: '',
+          timeShifts: [],
+          aliasTypes: [],
+          units: [],
+          process: true,
+          datasourceUid: 'target-uid',
+          targetQueryJSON: { query: 'moduleName: $moduleName' },
+        }],
+        { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } }
+      );
+
+      expect(result.targetQueryJSON).toEqual({ query: 'moduleName: {action,default,charge}' });
+    });
+
+    it('keeps an explicit variable format authoritative over the datasource fallback', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: createTemplateReplace(),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const [result] = ds.interpolateVariablesInQueries(
+        [{
+          refId: 'B',
+          query: '',
+          timeShifts: [],
+          aliasTypes: [],
+          units: [],
+          process: true,
+          datasourceUid: 'es-uid',
+          datasourceType: 'elasticsearch',
+          targetQueryJSON: { query: 'moduleName: ${moduleName:glob}' },
+        }],
+        { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } }
+      );
+
+      expect(result.targetQueryJSON).toEqual({
+        query: 'moduleName: {action,default,charge}',
+      });
+    });
+
+    it('applies the datasource fallback only to query fields', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: createTemplateReplace(),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const [result] = ds.interpolateVariablesInQueries(
+        [{
+          refId: 'B',
+          query: '',
+          timeShifts: [],
+          aliasTypes: [],
+          units: [],
+          process: true,
+          datasourceUid: 'es-uid',
+          datasourceType: 'elasticsearch',
+          targetQueryJSON: {
+            query: 'moduleName: $moduleName',
+            alias: '$moduleName',
+          },
+        }],
+        { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } }
+      );
+
+      expect(result.targetQueryJSON).toEqual({
+        query: 'moduleName: ("action" OR "default" OR "charge")',
+        alias: '{action,default,charge}',
+      });
+    });
+
+    it.each(['prometheus', 'loki'])(
+      'formats unformatted multi-value variables as regex for %s expressions',
+      (datasourceType) => {
+        mockGetTemplateSrv.mockReturnValue({
+          replace: createTemplateReplace(),
+        });
+
+        const ds = new DataSource({
+          id: 1,
+          meta: { id: 'leoswing-comparequeries-datasource' },
+          jsonData: {},
+        } as any);
+
+        const [result] = ds.interpolateVariablesInQueries(
+          [{
+            refId: 'A',
+            query: '',
+            timeShifts: [],
+            aliasTypes: [],
+            units: [],
+            process: true,
+            datasourceUid: `${datasourceType}-uid`,
+            datasourceType,
+            targetQueryJSON: {
+              expr: 'errors_total{module=~"$moduleName"}',
+              legendFormat: '$moduleName',
+            },
+          }],
+          { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } }
+        );
+
+        expect(result.targetQueryJSON).toEqual({
+          expr: 'errors_total{module=~"(action|default|charge)"}',
+          legendFormat: '{action,default,charge}',
+        });
+      }
+    );
+
+    it.each(['mysql', 'postgres', 'grafana-postgresql-datasource', 'mssql'])(
+      'formats unformatted multi-value variables as sqlstring for %s rawSql',
+      (datasourceType) => {
+        mockGetTemplateSrv.mockReturnValue({
+          replace: createTemplateReplace(),
+        });
+
+        const ds = new DataSource({
+          id: 1,
+          meta: { id: 'leoswing-comparequeries-datasource' },
+          jsonData: {},
+        } as any);
+
+        const [result] = ds.interpolateVariablesInQueries(
+          [{
+            refId: 'A',
+            query: '',
+            timeShifts: [],
+            aliasTypes: [],
+            units: [],
+            process: true,
+            datasourceUid: `${datasourceType}-uid`,
+            datasourceType,
+            targetQueryJSON: {
+              rawSql: 'SELECT * FROM events WHERE module_name IN ($moduleName)',
+            },
+          }],
+          { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } }
+        );
+
+        expect(result.targetQueryJSON).toEqual({
+          rawSql: "SELECT * FROM events WHERE module_name IN ('action','default','charge')",
+        });
+      }
+    );
+
+    it('formats unformatted multi-value variables as csv for CSV query fields', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: createTemplateReplace(),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const [result] = ds.interpolateVariablesInQueries(
+        [{
+          refId: 'A',
+          query: '',
+          timeShifts: [],
+          aliasTypes: [],
+          units: [],
+          process: true,
+          datasourceUid: 'csv-uid',
+          datasourceType: 'marcusolsson-csv-datasource',
+          targetQueryJSON: {
+            query: 'modules=$moduleName',
+          },
+        }],
+        { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } }
+      );
+
+      expect(result.targetQueryJSON).toEqual({
+        query: 'modules=action,default,charge',
+      });
+    });
+
+    it('formats unformatted multi-value variables as regex for InfluxQL query fields', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: createTemplateReplace(),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const [result] = ds.interpolateVariablesInQueries(
+        [{
+          refId: 'A',
+          query: '',
+          timeShifts: [],
+          aliasTypes: [],
+          units: [],
+          process: true,
+          datasourceUid: 'influx-uid',
+          datasourceType: 'influxdb',
+          targetQueryJSON: {
+            query: 'SELECT mean("value") FROM "logins" WHERE "hostname" =~ /^$moduleName$/',
+            alias: '$moduleName',
+          },
+        }],
+        { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } }
+      );
+
+      expect(result.targetQueryJSON).toEqual({
+        query: 'SELECT mean("value") FROM "logins" WHERE "hostname" =~ /^(action|default|charge)$/',
+        alias: '{action,default,charge}',
+      });
+    });
+
+    it('formats unformatted multi-value variables as pipe for OpenTSDB filter fields', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: createTemplateReplace(),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const [result] = ds.interpolateVariablesInQueries(
+        [{
+          refId: 'A',
+          query: '',
+          timeShifts: [],
+          aliasTypes: [],
+          units: [],
+          process: true,
+          datasourceUid: 'opentsdb-uid',
+          datasourceType: 'opentsdb',
+          targetQueryJSON: {
+            metric: 'sys.cpu.user',
+            filters: [
+              {
+                type: 'literal_or',
+                tagk: 'host',
+                filter: '$moduleName',
+              },
+            ],
+            alias: '$moduleName',
+          },
+        }],
+        { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } }
+      );
+
+      expect(result.targetQueryJSON).toEqual({
+        metric: 'sys.cpu.user',
+        filters: [
+          {
+            type: 'literal_or',
+            tagk: 'host',
+            filter: 'action|default|charge',
+          },
+        ],
+        alias: '{action,default,charge}',
+      });
+    });
+
+    it('does not apply an adapter to a datasource type that only contains a known type name', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: createTemplateReplace(),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const [result] = ds.interpolateVariablesInQueries(
+        [{
+          refId: 'A',
+          query: '',
+          timeShifts: [],
+          aliasTypes: [],
+          units: [],
+          process: true,
+          datasourceUid: 'custom-influx-uid',
+          datasourceType: 'custom-influx-wrapper-datasource',
+          targetQueryJSON: {
+            query: 'host=$moduleName',
+          },
+        }],
+        { moduleName: { value: ['action', 'default', 'charge'], text: 'action + default + charge' } }
+      );
+
+      expect(result.targetQueryJSON).toEqual({
+        query: 'host={action,default,charge}',
+      });
+    });
+
+    it('does not apply fallback formats to single-value variables', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: createTemplateReplace('action'),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const [result] = ds.interpolateVariablesInQueries(
+        [{
+          refId: 'A',
+          query: '',
+          timeShifts: [],
+          aliasTypes: [],
+          units: [],
+          process: true,
+          datasourceUid: 'mysql-uid',
+          datasourceType: 'mysql',
+          targetQueryJSON: {
+            rawSql: 'SELECT * FROM events WHERE module_name = $moduleName',
+          },
+        }],
+        { moduleName: { value: 'action', text: 'action' } }
+      );
+
+      expect(result.targetQueryJSON).toEqual({
+        rawSql: 'SELECT * FROM events WHERE module_name = action',
+      });
+    });
+
+    it('applyTemplateVariables expands timeShift value, alias, and delimiter', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: (value: string) =>
+          value
+            .replace(/\$shiftAlias/g, 'last_week')
+            .replace(/\$delimiter/g, ' / ')
+            .replace(/\$shift/g, '7d'),
+      });
+
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const query = {
+        refId: 'B',
+        query: '',
+        timeShifts: [
+          { id: 0, value: '', alias: '' },
+          { id: 1, value: '$shift', alias: '$shiftAlias', aliasType: 'suffix', delimiter: '$delimiter' },
+        ],
+        aliasTypes: [],
+        units: [],
+        process: true,
+      };
+      const scopedVars = {
+        shift: { value: '7d', text: '7d' },
+        shiftAlias: { value: 'last_week', text: 'last_week' },
+        delimiter: { value: ' / ', text: ' / ' },
+      };
+      const result = ds.applyTemplateVariables(query as any, scopedVars);
+
+      expect(result.timeShifts).toEqual([
+        { id: 0, value: '', alias: '', delimiter: '' },
+        { id: 1, value: '7d', alias: 'last_week', aliasType: 'suffix', delimiter: ' / ' },
+      ]);
+      expect(query.timeShifts[1]).toEqual({
+        id: 1,
+        value: '$shift',
+        alias: '$shiftAlias',
+        aliasType: 'suffix',
+        delimiter: '$delimiter',
+      });
+    });
+
     it('filters invalid non-empty shifts when at least one valid shift exists', async () => {
       const queryMock = jest.fn().mockResolvedValue({
         data: [{ target: 'error' }],
@@ -180,6 +1082,77 @@ describe('DataSource', () => {
       expect(queryMock).toHaveBeenCalledTimes(1);
       expect(result.data).toHaveLength(1);
       expect(result.data[0].target).toBe('error_1d');
+    });
+  });
+
+  describe('time-shift alias naming', () => {
+    it('keeps frame name separate from the aliased field name', () => {
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      const frame: any = {
+        name: 'test22',
+        fields: [
+          { name: 'Time', type: 'time', config: {} },
+          { name: 'Value', type: 'number', config: {} },
+        ],
+      };
+
+      (ds as any)._applyAliasToFrame(frame, '1d', 'suffix', '_');
+
+      expect(frame.name).toBe('test22');
+      expect(frame.fields[1].name).toBe('Value_1d');
+      expect(frame.fields[1].config.displayNameFromDS).toBe('test22_1d');
+      expect(frame.fields[1].labels).toEqual({ timeshift: '1d' });
+    });
+
+    it('keeps wide-frame field display names distinct', () => {
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+      const frame: any = {
+        name: 'orders',
+        fields: [
+          { name: 'Time', type: 'time', config: {} },
+          { name: 'success', type: 'number', config: {} },
+          { name: 'failure', type: 'number', config: {} },
+        ],
+      };
+
+      (ds as any)._applyAliasToFrame(frame, '1d', 'suffix', '_');
+
+      expect(frame.fields[1].name).toBe('success_1d');
+      expect(frame.fields[2].name).toBe('failure_1d');
+      expect(frame.fields[1].config.displayNameFromDS).toBe('success_1d');
+      expect(frame.fields[2].config.displayNameFromDS).toBe('failure_1d');
+    });
+
+    it('keeps mixed-frame field display names distinct', () => {
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+      const frame: any = {
+        name: 'orders',
+        fields: [
+          { name: 'Time', type: 'time', config: {} },
+          { name: 'status', type: 'string', config: {} },
+          { name: 'count', type: 'number', config: {} },
+        ],
+      };
+
+      (ds as any)._applyAliasToFrame(frame, '1d', 'suffix', '_');
+
+      expect(frame.fields[1].name).toBe('status_1d');
+      expect(frame.fields[1].config.displayNameFromDS).toBe('status_1d');
+      expect(frame.fields[2].name).toBe('count_1d');
+      expect(frame.fields[2].config.displayNameFromDS).toBe('count_1d');
     });
   });
 
@@ -251,6 +1224,21 @@ describe('DataSource', () => {
 
       expect(datasourceSrv.get).toHaveBeenCalledWith('prometheus-uid');
       expect(compareQueryMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('ad hoc variable support', () => {
+    it('exposes getTagKeys/getTagValues so Grafana can bind Ad hoc variables', async () => {
+      const ds = new DataSource({
+        id: 1,
+        meta: { id: 'leoswing-comparequeries-datasource' },
+        jsonData: {},
+      } as any);
+
+      expect(typeof ds.getTagKeys).toBe('function');
+      expect(typeof ds.getTagValues).toBe('function');
+      await expect(ds.getTagKeys()).resolves.toEqual([]);
+      await expect(ds.getTagValues({ key: 'moduleName' } as any)).resolves.toEqual([]);
     });
   });
 });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -7,6 +7,11 @@ import {
   DataFrame,
   FieldType,
   Field,
+  ScopedVars,
+  AdHocVariableFilter,
+  DataSourceGetTagKeysOptions,
+  DataSourceGetTagValuesOptions,
+  MetricFindValue,
 } from '@grafana/data';
 import { getDataSourceSrv, DataSourceSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 
@@ -15,6 +20,18 @@ import _ from 'lodash';
 // eslint-disable-next-line no-restricted-imports
 import moment from 'moment';
 import { TIMESHIFT_FORMAT_REG } from './config';
+import {
+  getTargetInterpolationMode,
+  interpolateTargetQueryJSON,
+  isPlainObject,
+  markTargetInterpolationMode,
+  normalizeTargetQueryJSON,
+  prepareTargetQueryJSON,
+  supportsTemplateVariableDelegation,
+  TargetInterpolationContext,
+  TargetInterpolationOptions,
+  TemplateVariableDelegate,
+} from './interpolation/target-interpolation';
 
 export class DataSource extends DataSourceApi<CompareQueriesQuery, CompareQueriesOptions> {
   id: number;
@@ -23,6 +40,10 @@ export class DataSource extends DataSourceApi<CompareQueriesQuery, CompareQuerie
   meta: any;
   units = ['y', 'M', 'w', 'd', 'h', 'm', 's'];
 
+  // QueryEditor and query execution both resolve target datasource instances. Keep only the
+  // interpolation capability here so synchronous backend/expression preparation can delegate.
+  private _targetDsCache = new Map<string, TemplateVariableDelegate>();
+
   constructor(instanceSettings: DataSourceInstanceSettings<CompareQueriesOptions>) {
     super(instanceSettings);
 
@@ -30,6 +51,114 @@ export class DataSource extends DataSourceApi<CompareQueriesQuery, CompareQuerie
     this.meta = instanceSettings.meta;
     this.datasourceSrv = getDataSourceSrv();
     this.templateSrv = getTemplateSrv();
+  }
+
+  registerTargetDatasource(uid: string, datasource: unknown): void {
+    if (supportsTemplateVariableDelegation(datasource)) {
+      this._targetDsCache.set(uid, datasource);
+    }
+  }
+
+  private _interpolationContext(): TargetInterpolationContext {
+    return {
+      templateSrv: this.templateSrv,
+      datasourceSrv: this.datasourceSrv,
+      targetDsCache: this._targetDsCache,
+      resolveDatasourceType: (uid) => this._resolveDatasourceType(uid),
+      getLegacyAdHocFilters: () => this._getLegacyAdHocFilters(),
+    };
+  }
+
+  private _resolveDatasourceType(uid: string | undefined): string | undefined {
+    if (!uid) {
+      return undefined;
+    }
+    const getInstanceSettings = Reflect.get(this.datasourceSrv as object, 'getInstanceSettings');
+    if (typeof getInstanceSettings !== 'function') {
+      return undefined;
+    }
+    try {
+      const settings = getInstanceSettings.call(this.datasourceSrv, uid);
+      if (isPlainObject(settings)) {
+        const datasourceType = Reflect.get(settings, 'type');
+        return typeof datasourceType === 'string' ? datasourceType : undefined;
+      }
+    } catch {
+      return undefined;
+    }
+    return undefined;
+  }
+
+  // Grafana calls this before backend QueryData (expressions / alerting). Delegate target query
+  // interpolation when the native datasource instance is available; otherwise use Grafana's
+  // formatter through a narrow, field-aware fallback adapter.
+  applyTemplateVariables(
+    query: CompareQueriesQuery,
+    scopedVars: ScopedVars,
+    filters?: AdHocVariableFilter[]
+  ): CompareQueriesQuery {
+    return this._applyTemplateVariables(query, scopedVars, filters);
+  }
+
+  interpolateVariablesInQueries(
+    queries: CompareQueriesQuery[],
+    scopedVars: ScopedVars,
+    filters?: AdHocVariableFilter[]
+  ): CompareQueriesQuery[] {
+    // Grafana expressions call this method before forwarding queries to backend QueryData.
+    // Therefore an unavailable delegate must still use the default glob fallback.
+    return queries.map((query) => this._applyTemplateVariables(query, scopedVars, filters));
+  }
+
+  private _applyTemplateVariables(
+    query: CompareQueriesQuery,
+    scopedVars: ScopedVars,
+    filters?: AdHocVariableFilter[]
+  ): CompareQueriesQuery {
+    const next: CompareQueriesQuery = { ...query };
+
+    if (query.targetQueryJSON !== undefined) {
+      const interpolation = prepareTargetQueryJSON(
+        query.targetQueryJSON,
+        scopedVars,
+        {
+          datasourceUid: query.datasourceUid,
+          datasourceType: query.datasourceType ?? this._resolveDatasourceType(query.datasourceUid),
+          refId: query.refId,
+          filters,
+        },
+        this._interpolationContext()
+      );
+      if (interpolation !== null) {
+        next.targetQueryJSON = interpolation.query;
+        markTargetInterpolationMode(next, interpolation.mode);
+      }
+    }
+
+    if (Array.isArray(query.timeShifts)) {
+      next.timeShifts = query.timeShifts.map((ts) => ({
+        ...ts,
+        value: this.templateSrv.replace(ts?.value ?? '', scopedVars),
+        alias: this.templateSrv.replace(ts?.alias ?? '', scopedVars),
+        delimiter: this.templateSrv.replace(ts?.delimiter ?? '', scopedVars),
+      }));
+    }
+
+    return next;
+  }
+
+  private _getLegacyAdHocFilters(): AdHocVariableFilter[] {
+    const legacyGetAdhocFilters = Reflect.get(this.templateSrv as object, 'getAdhocFilters');
+    if (typeof legacyGetAdhocFilters !== 'function') {
+      return [];
+    }
+
+    try {
+      const resolved = legacyGetAdhocFilters.call(this.templateSrv, this.name);
+      return Array.isArray(resolved) ? resolved : [];
+    } catch {
+      return [];
+    }
   }
 
   getValueFieldName(line: DataFrame) {
@@ -178,7 +307,23 @@ export class DataSource extends DataSourceApi<CompareQueriesQuery, CompareQuerie
       return { data: [] };
     }
 
-    const baseQuery = this._normalizeTargetQueryJSON(target.targetQueryJSON);
+    this.registerTargetDatasource(target.datasourceUid, ds);
+
+    const previousInterpolation = getTargetInterpolationMode(target);
+    const baseQuery = previousInterpolation === 'delegated'
+      ? normalizeTargetQueryJSON(target.targetQueryJSON)
+      : prepareTargetQueryJSON(
+          target.targetQueryJSON,
+          options.scopedVars,
+          {
+            datasourceUid: target.datasourceUid,
+            datasourceType: target.datasourceType ?? this._resolveDatasourceType(target.datasourceUid),
+            refId: target.refId,
+            delegate: ds,
+            filters: options.filters,
+          },
+          this._interpolationContext()
+        )?.query ?? null;
     if (baseQuery === null) {
       console.warn('CompareQueries: targetQueryJSON is not valid JSON', target.targetQueryJSON);
       return { data: [] };
@@ -211,25 +356,17 @@ export class DataSource extends DataSourceApi<CompareQueriesQuery, CompareQuerie
     };
   }
 
+  // Test/compat wrappers — logic lives in interpolation/target-interpolation.ts
   _normalizeTargetQueryJSON(payload: any): Record<string, any> | null {
-    if (payload === undefined || payload === null) {
-      return null;
-    }
-    if (typeof payload === 'object') {
-      return _.cloneDeep(payload);
-    }
-    if (typeof payload === 'string') {
-      const trimmed = payload.trim();
-      if (trimmed === '') {
-        return null;
-      }
-      try {
-        return JSON.parse(trimmed);
-      } catch {
-        return null;
-      }
-    }
-    return null;
+    return normalizeTargetQueryJSON(payload);
+  }
+
+  _interpolateTargetQueryJSON(
+    payload: Record<string, any> | string | undefined | null,
+    scopedVars: ScopedVars,
+    options: TargetInterpolationOptions = {}
+  ): Record<string, any> | null {
+    return interpolateTargetQueryJSON(payload, scopedVars, options, this._interpolationContext());
   }
 
   async _runOneShift(
@@ -294,7 +431,7 @@ export class DataSource extends DataSourceApi<CompareQueriesQuery, CompareQuerie
     if (isShifted) {
       const alias = this.templateSrv.replace(ts.alias, options.scopedVars) || shiftValue;
       const aliasType = ts.aliasType || 'suffix';
-      const delimiter = ts.delimiter || '_';
+      const delimiter = this.templateSrv.replace(ts.delimiter ?? '', options.scopedVars) || '_';
       const shiftMs = target.process ? this.parseShiftToMs(shiftValue) : undefined;
 
       result.data.forEach((line: any) => {
@@ -459,24 +596,49 @@ export class DataSource extends DataSourceApi<CompareQueriesQuery, CompareQuerie
       if (typeof line.title !== 'undefined' && line.title !== null) {
         line.title = this.generalAlias(line.title, alias, aliasType, delimiter);
       }
-    } else if (line.fields) {
-      // New data frame format
+      return;
+    }
+
+    if (line.fields) {
+      // Keep frame.name separate from field.name, and use Grafana's display-name resolver
+      // to produce one final alias without appending frame/field/label parts again.
       line.fields.forEach((field: Record<string, any>) => {
-        if (field.name) {
-          const valueFieldName = this.getValueFieldName(line);
-          const inputName = field.type === FieldType.number && valueFieldName ? valueFieldName : field.name;
-          if (field.type === FieldType.number) {
-            field.name = this.generalAlias(inputName, alias, aliasType, delimiter);
-          }
+        if (field.type === FieldType.time) {
+          return;
         }
-        if (field.config && field.config.displayName) {
+
+        const datasourceDisplayName = getFieldDisplayName(field as Field, line);
+        if (field.name) {
+          field.name = this.generalAlias(field.name, alias, aliasType, delimiter);
+        }
+
+        field.config = field.config || {};
+        if (field.config.displayName) {
           field.config.displayName = this.generalAlias(field.config.displayName, alias, aliasType, delimiter);
         }
-        if (field.config && field.config.displayNameFromDS) {
-          field.config.displayNameFromDS = this.generalAlias(field.config.displayNameFromDS, alias, aliasType, delimiter);
+
+        if (field.config.displayNameFromDS) {
+          field.config.displayNameFromDS = this.generalAlias(
+            field.config.displayNameFromDS,
+            alias,
+            aliasType,
+            delimiter
+          );
+        } else if (datasourceDisplayName) {
+          field.config.displayNameFromDS = this.generalAlias(
+            datasourceDisplayName,
+            alias,
+            aliasType,
+            delimiter
+          );
         }
+
+        field.labels = { ...(field.labels || {}), timeshift: alias };
       });
-    } else if (line.columns) {
+      return;
+    }
+
+    if (line.columns) {
       // Table format — skip first column for joins
       for (let i = 1; i < line.columns.length; i++) {
         const column = line.columns[i];
@@ -553,7 +715,7 @@ export class DataSource extends DataSourceApi<CompareQueriesQuery, CompareQuerie
             let timeShiftValue: any;
             let timeShiftAlias: any;
             let aliasType = timeShift.aliasType || 'suffix';
-            let delimiter = timeShift.delimiter || '_';
+            let delimiter = '_';
 
             let comparePromise = _this.datasourceSrv
               .get(compareDsName)
@@ -561,9 +723,9 @@ export class DataSource extends DataSourceApi<CompareQueriesQuery, CompareQuerie
                 if (compareDs.meta.id === _this.meta.id) {
                   return { data: [] };
                 }
-
                 timeShiftValue = _this.templateSrv.replace(timeShift.value, options.scopedVars);
                 timeShiftAlias = _this.templateSrv.replace(timeShift.alias, options.scopedVars) || timeShiftValue;
+                delimiter = _this.templateSrv.replace(timeShift.delimiter ?? '', options.scopedVars) || '_';
 
                 if (timeShiftValue === null || timeShiftValue === '' || typeof timeShiftValue === 'undefined' || !TIMESHIFT_FORMAT_REG.test(timeShiftValue)) {
                   return { data: [] };
@@ -697,6 +859,17 @@ export class DataSource extends DataSourceApi<CompareQueriesQuery, CompareQuerie
 
       return shiftTime;
     }
+  }
+
+  // Grafana checks ds.getTagKeys to decide whether a datasource can back Ad hoc variables.
+  // CompareQueries does not discover fields itself; use static key dimensions on the variable
+  // and forward filters to the target datasource during query execution.
+  async getTagKeys(_options?: DataSourceGetTagKeysOptions): Promise<MetricFindValue[]> {
+    return [];
+  }
+
+  async getTagValues(_options: DataSourceGetTagValuesOptions): Promise<MetricFindValue[]> {
+    return [];
   }
 
   async testDatasource() {

--- a/src/interpolation/fallback-format-adapters.ts
+++ b/src/interpolation/fallback-format-adapters.ts
@@ -1,0 +1,101 @@
+import { ScopedVars } from '@grafana/data';
+import _ from 'lodash';
+
+export type VariableFormat = 'csv' | 'lucene' | 'pipe' | 'regex' | 'sqlstring';
+
+export interface FallbackFormatAdapter {
+  formatForPath(path: string[]): VariableFormat | undefined;
+}
+
+const LUCENE_QUERY_ADAPTER: FallbackFormatAdapter = {
+  formatForPath: (path) => (path[path.length - 1] === 'query' ? 'lucene' : undefined),
+};
+
+const REGEX_EXPRESSION_ADAPTER: FallbackFormatAdapter = {
+  formatForPath: (path) => (path[path.length - 1] === 'expr' ? 'regex' : undefined),
+};
+
+// InfluxQL multi-value tags use =~ with a regex. InfluxDB SQL mode still prefers warm
+// delegate or an explicit ${var:sqlstring}; this fallback only covers the query field.
+const INFLUXQL_QUERY_ADAPTER: FallbackFormatAdapter = {
+  formatForPath: (path) => (path[path.length - 1] === 'query' ? 'regex' : undefined),
+};
+
+const SQL_QUERY_ADAPTER: FallbackFormatAdapter = {
+  formatForPath: (path) => (path[path.length - 1] === 'rawSql' ? 'sqlstring' : undefined),
+};
+
+const CSV_QUERY_ADAPTER: FallbackFormatAdapter = {
+  formatForPath: (path) => (['query', 'rawQuery'].includes(path[path.length - 1]) ? 'csv' : undefined),
+};
+
+// OpenTSDB literal_or filters expect pipe-separated values in the filter field.
+const OPENTSDB_PIPE_ADAPTER: FallbackFormatAdapter = {
+  formatForPath: (path) => (path[path.length - 1] === 'filter' ? 'pipe' : undefined),
+};
+
+const DATASOURCE_TYPE_FORMAT_ADAPTERS = new Map<string, FallbackFormatAdapter>([
+  ['elasticsearch', LUCENE_QUERY_ADAPTER],
+  ['grafana-opensearch-datasource', LUCENE_QUERY_ADAPTER],
+  ['prometheus', REGEX_EXPRESSION_ADAPTER],
+  ['loki', REGEX_EXPRESSION_ADAPTER],
+  ['mysql', SQL_QUERY_ADAPTER],
+  // Grafana 9 uses the legacy core ID; Grafana 10–13 use the plugin ID.
+  ['postgres', SQL_QUERY_ADAPTER],
+  ['grafana-postgresql-datasource', SQL_QUERY_ADAPTER],
+  ['mssql', SQL_QUERY_ADAPTER],
+  ['marcusolsson-csv-datasource', CSV_QUERY_ADAPTER],
+  ['influxdb', INFLUXQL_QUERY_ADAPTER],
+  ['opentsdb', OPENTSDB_PIPE_ADAPTER],
+]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function resolveFallbackFormatAdapter(
+  datasourceType: string | undefined
+): FallbackFormatAdapter | undefined {
+  if (!datasourceType) {
+    return undefined;
+  }
+  return DATASOURCE_TYPE_FORMAT_ADAPTERS.get(datasourceType.toLowerCase());
+}
+
+function stringifyVariableValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value);
+}
+
+export function formatMultiValueFallback(value: unknown[], format: VariableFormat): string {
+  const values = value.map(stringifyVariableValue);
+  switch (format) {
+    case 'csv':
+      return values.join(',');
+    case 'pipe':
+      return values.join('|');
+    case 'lucene':
+      return `(${values
+        .map((item) => `"${item.replace(/([+\-=&|><!(){}[\]^"~*?:\\/])/g, '\\$1')}"`)
+        .join(' OR ')})`;
+    case 'regex':
+      return `(${values.map((item) => _.escapeRegExp(item)).join('|')})`;
+    case 'sqlstring':
+      return values.map((item) => `'${item.replace(/'/g, "''")}'`).join(',');
+  }
+}
+
+export function createMultiValueFormatter(format: VariableFormat, scopedVars: ScopedVars) {
+  return (value: unknown, variable: unknown): string => {
+    const variableName = isPlainObject(variable) ? Reflect.get(variable, 'name') : undefined;
+    const scopedVar = typeof variableName === 'string' ? scopedVars[variableName] : undefined;
+    const scopedValue = isPlainObject(scopedVar) ? Reflect.get(scopedVar, 'value') : undefined;
+    const effectiveValue = Array.isArray(scopedValue) ? scopedValue : value;
+
+    return Array.isArray(effectiveValue) && effectiveValue.length > 1
+      ? formatMultiValueFallback(effectiveValue, format)
+      : stringifyVariableValue(Array.isArray(effectiveValue) ? effectiveValue[0] : effectiveValue);
+  };
+}

--- a/src/interpolation/target-interpolation.ts
+++ b/src/interpolation/target-interpolation.ts
@@ -1,0 +1,268 @@
+import { AdHocVariableFilter, ScopedVars } from '@grafana/data';
+import { DataSourceSrv, TemplateSrv } from '@grafana/runtime';
+import _ from 'lodash';
+
+import {
+  createMultiValueFormatter,
+  FallbackFormatAdapter,
+  resolveFallbackFormatAdapter,
+} from './fallback-format-adapters';
+
+const RESERVED_TARGET_QUERY_FIELDS = new Set(['refId', 'datasource', 'key', 'hide']);
+export const TARGET_QUERY_INTERPOLATION = Symbol('compareQueriesTargetInterpolation');
+
+export type TargetInterpolationMode = 'delegated' | 'fallback';
+
+export interface TemplateVariableDelegate {
+  applyTemplateVariables(
+    query: Record<string, unknown>,
+    scopedVars: ScopedVars,
+    filters?: AdHocVariableFilter[]
+  ): unknown;
+}
+
+export interface TargetInterpolationOptions {
+  datasourceUid?: string;
+  datasourceType?: string;
+  refId?: string;
+  delegate?: unknown;
+  filters?: AdHocVariableFilter[];
+}
+
+export interface TargetInterpolationResult {
+  query: Record<string, any>;
+  mode: TargetInterpolationMode;
+}
+
+export interface TargetInterpolationContext {
+  templateSrv: TemplateSrv;
+  datasourceSrv: DataSourceSrv;
+  targetDsCache: Map<string, TemplateVariableDelegate>;
+  resolveDatasourceType: (uid?: string) => string | undefined;
+  getLegacyAdHocFilters: () => AdHocVariableFilter[];
+}
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function supportsTemplateVariableDelegation(
+  value: unknown
+): value is TemplateVariableDelegate {
+  return isPlainObject(value) && typeof Reflect.get(value, 'applyTemplateVariables') === 'function';
+}
+
+function applyTemplateVariablesWithLegacyFilters(
+  delegate: TemplateVariableDelegate,
+  query: Record<string, unknown>,
+  scopedVars: ScopedVars,
+  filters: AdHocVariableFilter[]
+): unknown {
+  const applyTemplateVariables = delegate.applyTemplateVariables;
+  const templateSrv = Reflect.get(delegate as object, 'templateSrv');
+  if (!isPlainObject(templateSrv) || typeof Reflect.get(templateSrv, 'getAdhocFilters') !== 'function') {
+    return applyTemplateVariables.call(delegate, query, scopedVars, filters);
+  }
+
+  // Scope the compatibility override to this invocation. Mutating the shared datasource or
+  // TemplateSrv would leak CompareQueries filters into concurrent queries and other panels.
+  const compatibleTemplateSrv = Object.create(templateSrv);
+  Object.defineProperty(compatibleTemplateSrv, 'getAdhocFilters', {
+    value: () => filters,
+  });
+
+  const compatibleDelegate = Object.create(delegate) as TemplateVariableDelegate;
+  Object.defineProperty(compatibleDelegate, 'templateSrv', {
+    value: compatibleTemplateSrv,
+  });
+
+  return applyTemplateVariables.call(compatibleDelegate, query, scopedVars, filters);
+}
+
+export function getLoadedTemplateVariableDelegate(
+  datasourceSrv: DataSourceSrv,
+  uid: string
+): TemplateVariableDelegate | undefined {
+  // ExpressionDatasource loads all source datasources before synchronously interpolating them.
+  // Grafana's public DataSourceSrv.get() is async, so use its already-loaded instance registry
+  // to bridge that synchronous API boundary. Fall back safely if Grafana changes the registry.
+  const loadedDatasources = Reflect.get(datasourceSrv, 'datasources');
+  if (!isPlainObject(loadedDatasources)) {
+    return undefined;
+  }
+
+  const datasource = loadedDatasources[uid];
+  return supportsTemplateVariableDelegation(datasource) ? datasource : undefined;
+}
+
+export function getTargetInterpolationMode(value: unknown): TargetInterpolationMode | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+  const mode = Reflect.get(value, TARGET_QUERY_INTERPOLATION);
+  return mode === 'delegated' || mode === 'fallback' ? mode : undefined;
+}
+
+export function markTargetInterpolationMode<T extends object>(
+  target: T,
+  mode: TargetInterpolationMode
+): T {
+  Object.defineProperty(target, TARGET_QUERY_INTERPOLATION, {
+    value: mode,
+    enumerable: true,
+  });
+  return target;
+}
+
+export function normalizeTargetQueryJSON(payload: unknown): Record<string, any> | null {
+  if (payload === undefined || payload === null) {
+    return null;
+  }
+  if (typeof payload === 'object') {
+    return _.cloneDeep(payload);
+  }
+  if (typeof payload === 'string') {
+    const trimmed = payload.trim();
+    if (trimmed === '') {
+      return null;
+    }
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+export function stripReservedTargetQueryFields(payload: Record<string, unknown>): Record<string, any> {
+  const out: Record<string, any> = {};
+  for (const key of Object.keys(payload)) {
+    if (!RESERVED_TARGET_QUERY_FIELDS.has(key)) {
+      out[key] = payload[key];
+    }
+  }
+  return out;
+}
+
+function applyTargetTemplateVariables(
+  delegate: TemplateVariableDelegate,
+  query: Record<string, unknown>,
+  scopedVars: ScopedVars,
+  filters: AdHocVariableFilter[] | undefined,
+  getLegacyAdHocFilters: () => AdHocVariableFilter[]
+): unknown {
+  // A defined value, including [], is authoritative under Grafana's modern request contract.
+  if (filters !== undefined) {
+    return delegate.applyTemplateVariables(query, scopedVars, filters);
+  }
+
+  const legacyFilters = getLegacyAdHocFilters();
+  return legacyFilters.length > 0
+    ? applyTemplateVariablesWithLegacyFilters(delegate, query, scopedVars, legacyFilters)
+    : delegate.applyTemplateVariables(query, scopedVars);
+}
+
+export function deepReplaceTemplateVars(
+  value: unknown,
+  scopedVars: ScopedVars,
+  templateSrv: TemplateSrv,
+  adapter?: FallbackFormatAdapter,
+  path: string[] = []
+): unknown {
+  if (typeof value === 'string') {
+    if (!value.includes('$')) {
+      return value;
+    }
+    const defaultFormat = adapter?.formatForPath(path);
+    return templateSrv.replace(
+      value,
+      scopedVars,
+      defaultFormat ? createMultiValueFormatter(defaultFormat, scopedVars) : undefined
+    );
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item, index) =>
+      deepReplaceTemplateVars(item, scopedVars, templateSrv, adapter, [...path, String(index)])
+    );
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, nested]) => [
+        key,
+        deepReplaceTemplateVars(nested, scopedVars, templateSrv, adapter, [...path, key]),
+      ])
+    );
+  }
+
+  return value;
+}
+
+export function prepareTargetQueryJSON(
+  payload: Record<string, any> | string | undefined | null,
+  scopedVars: ScopedVars,
+  options: TargetInterpolationOptions,
+  context: TargetInterpolationContext
+): TargetInterpolationResult | null {
+  const normalized = normalizeTargetQueryJSON(payload);
+  if (normalized === null) {
+    return null;
+  }
+
+  const delegate = supportsTemplateVariableDelegation(options.delegate)
+    ? options.delegate
+    : options.datasourceUid
+      ? context.targetDsCache.get(options.datasourceUid) ??
+        getLoadedTemplateVariableDelegate(context.datasourceSrv, options.datasourceUid)
+      : undefined;
+
+  if (delegate && options.datasourceUid) {
+    context.targetDsCache.set(options.datasourceUid, delegate);
+  }
+
+  if (delegate) {
+    try {
+      const fullQuery = {
+        ...normalized,
+        refId: options.refId || 'A',
+        datasource: options.datasourceUid ? { uid: options.datasourceUid } : undefined,
+      };
+      const result = applyTargetTemplateVariables(
+        delegate,
+        fullQuery,
+        scopedVars,
+        options.filters,
+        context.getLegacyAdHocFilters
+      );
+      if (isPlainObject(result)) {
+        return {
+          query: stripReservedTargetQueryFields(result),
+          mode: 'delegated',
+        };
+      }
+    } catch (err) {
+      console.warn('CompareQueries: target applyTemplateVariables failed, using fallback', err);
+    }
+  }
+
+  const datasourceType = options.datasourceType ?? context.resolveDatasourceType(options.datasourceUid);
+  const adapter = resolveFallbackFormatAdapter(datasourceType);
+  const interpolated = deepReplaceTemplateVars(normalized, scopedVars, context.templateSrv, adapter);
+  return isPlainObject(interpolated)
+    ? {
+        query: stripReservedTargetQueryFields(interpolated),
+        mode: 'fallback',
+      }
+    : null;
+}
+
+export function interpolateTargetQueryJSON(
+  payload: Record<string, any> | string | undefined | null,
+  scopedVars: ScopedVars,
+  options: TargetInterpolationOptions,
+  context: TargetInterpolationContext
+): Record<string, any> | null {
+  return prepareTargetQueryJSON(payload, scopedVars, options, context)?.query ?? null;
+}

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -9,3 +9,30 @@ test('data query should return a value', async ({ panelEditPage, readProvisioned
   await expect(panelEditPage.panel.fieldNames).toContainText(['Time', 'Value']);
   await expect(panelEditPage.panel.data).toContainText(['10']);
 });
+
+test('expression requests expand multi-value variables before backend QueryData', async ({
+  page,
+  readProvisionedDashboard,
+}) => {
+  const dashboard = await readProvisionedDashboard({
+    fileName: 'variable-expression.json',
+  });
+  const queryRequest = page.waitForRequest((request) => {
+    if (!request.url().includes('/api/ds/query')) {
+      return false;
+    }
+    return request.postData()?.includes('comparequeries-e2e') ?? false;
+  });
+
+  await page.goto(`/d/${dashboard.uid}`, { waitUntil: 'domcontentloaded' });
+
+  const request = await queryRequest;
+  const body = request.postDataJSON();
+  const compareQuery = body.queries.find(
+    (query: { datasource?: { uid?: string } }) => query.datasource?.uid === 'comparequeries-e2e'
+  );
+  const targetQuery = compareQuery?.targetQueryJSON?.query;
+
+  expect(targetQuery).toBe('type:log AND moduleName: ("action" OR "default" OR "charge")');
+  expect(targetQuery).not.toContain('$moduleName');
+});


### PR DESCRIPTION
feat: support var template in plugin replacement

- Add AdHoc filter support, with Grafana 9+ support, Grafana 10 ~ 13 tested ok
- Upgrade expression support for variable, close #40 
- Optimize label name in plugin